### PR TITLE
Hoarder enhancement

### DIFF
--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT

--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -19,9 +19,9 @@ EOF
 header_info
 echo -e "Loading..."
 APP="Hoarder"
-var_disk="10"
-var_cpu="4"
-var_ram="4096"
+var_disk="8"
+var_cpu="2"
+var_ram="2048"
 var_os="debian"
 var_version="12"
 variables
@@ -60,7 +60,7 @@ if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
 fi
 RELEASE=$(curl -s https://api.github.com/repos/msgbyte/hoarder/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
-  whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
+#  whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
   msg_info "Stopping ${APP} Service"
   systemctl stop hoarder
   msg_ok "Stopped ${APP} Service"

--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/build.func)
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT

--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -21,7 +21,7 @@ echo -e "Loading..."
 APP="Hoarder"
 var_disk="8"
 var_cpu="2"
-var_ram="2048"
+var_ram="3072"
 var_os="debian"
 var_version="12"
 variables

--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -21,7 +21,7 @@ echo -e "Loading..."
 APP="Hoarder"
 var_disk="8"
 var_cpu="2"
-var_ram="3072"
+var_ram="4096"
 var_os="debian"
 var_version="12"
 variables
@@ -53,14 +53,11 @@ function default_settings() {
 }
 function update_script() {
 header_info
+check_container_storage
+check_container_resources
 if [[ ! -d /opt/hoarder ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
-if (( $(df /boot | awk 'NR==2{gsub("%","",$5); print $5}') > 80 )); then
-  read -r -p "Warning: Storage is dangerously low, continue anyway? <y/N> " prompt
-  [[ ${prompt,,} =~ ^(y|yes)$ ]] || exit
-fi
 RELEASE=$(curl -s https://api.github.com/repos/msgbyte/hoarder/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
-#  whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
   msg_info "Stopping ${APP} Service"
   systemctl stop hoarder
   msg_ok "Stopped ${APP} Service"
@@ -104,10 +101,9 @@ start
 build_container
 description
 
-msg_info "Setting Container to Normal Resources"
-pct set $CTID -memory 1024
-pct set $CTID -cores 1
-msg_ok "Set Container to Normal Resources"
+msg_info "Setting Container RAM to 2GB"
+pct set $CTID -memory 2048
+msg_ok "RAM set to 2GB"
 
 msg_ok "Completed Successfully!\n"
 echo -e "${APP} Setup should be reachable by going to the following URL.

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -47,7 +47,7 @@ $STD npm install -g pnpm
 export NODE_OPTIONS="--max_old_space_size=4096"
 msg_ok "Installed Node.js"
 
-msg_info "Installing Hoarder (Extreme Patience)"
+msg_info "Installing Hoarder"
 cd /opt
 RELEASE=$(curl -s https://api.github.com/repos/hoarder-app/hoarder/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 wget -q "https://github.com/hoarder-app/hoarder/archive/refs/tags/v${RELEASE}.zip"

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -85,7 +85,7 @@ echo -e "Meilisearch Master Key: $MEILI_SECRET" >>~/hoarder.creds
 
 cat <<EOF >$ENV_FILE
 NEXTAUTH_SECRET="$HOARDER_SECRET"
-NEXTAUTH_URL=
+NEXTAUTH_URL="https://localhost:3000"
 DATA_DIR="$DATA_DIR"
 MEILI_ADDR="http://127.0.0.1:7700"
 MEILI_MASTER_KEY="$MEILI_SECRET"

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -15,7 +15,6 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-# python3 \
   g++ \
   build-essential \
   curl \

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
+msg_info "Installing Dependencies (Patience)"
 $STD apt-get install -y \
   g++ \
   build-essential \
@@ -43,7 +43,7 @@ $STD apt-get update
 $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
-msg_info "Installing Hoarder (Patience)"
+msg_info "Installing Hoarder (More patience)"
 
 TMP_DIR=/tmp/hoarder
 INSTALL_DIR=/opt/hoarder
@@ -216,13 +216,19 @@ Wants=hoarder-web.service hoarder-workers.service hoarder-browser.service
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now meilisearch.service hoarder.target
+
 msg_ok "Created users and Services"
+
+msg_info "Performing database migration"
+export DATA_DIR=$DATA_DIR && cd $INSTALL_DIR/packages/db && pnpm migrate \
+  && chown -R hoarder:hoarder $DATA_DIR
+msg_ok "Migrated database"
 
 motd_ssh
 customize
 
 msg_info "Cleaning up"
+systemctl enable -q --now meilisearch.service hoarder.target
 rm -R $TMP_DIR
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -85,7 +85,7 @@ echo -e "Meilisearch Master Key: $MEILI_SECRET" >>~/hoarder.creds
 
 cat <<EOF >$ENV_FILE
 NEXTAUTH_SECRET="$HOARDER_SECRET"
-NEXTAUTH_URL="https://localhost:3000"
+NEXTAUTH_URL="http://localhost:3000"
 DATA_DIR="$DATA_DIR"
 MEILI_ADDR="http://127.0.0.1:7700"
 MEILI_MASTER_KEY="$MEILI_SECRET"

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -15,44 +15,38 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  postgresql \
-  python3 \
+# python3 \
   g++ \
   build-essential \
   curl \
   sudo \
   gnupg \
   ca-certificates \
+  chromium-shell \
   mc
+
+wget -q https://github.com/Y2Z/monolith/releases/latest/download/monolith-gnu-linux-x86_64 -O monolith && \
+  chmod +x monolith && mv monolith /usr/bin
+
+wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -O yt-dlp && \
+  chmod +x yt-dlp && mv yt-dlp /usr/bin
+
+wget -q https://github.com/meilisearch/meilisearch/releases/latest/download/meilisearch.deb && \
+  dpkg -i meilisearch.deb && rm meilisearch.deb
+
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Node.js"
+export NEXT_TELEMETRY_DISABLED=1
+export PUPPETEER_SKIP_DOWNLOAD="true"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 $STD apt-get update
 $STD apt-get install -y nodejs
 $STD npm install -g pnpm
-$STD pnpm add typescript
 export NODE_OPTIONS="--max_old_space_size=4096"
 msg_ok "Installed Node.js"
-
-msg_info "Setting up PostgreSQL"
-DB_NAME=hoarder_db
-DB_USER=hoarder_user
-DB_PASS="$(openssl rand -base64 18 | cut -c1-13)"
-HOARDER_SECRET="$(openssl rand -base64 32 | cut -c1-24)"
-$STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME;"
-$STD sudo -u postgres psql -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';"
-$STD sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;" 
-$STD sudo -u postgres psql -c "ALTER DATABASE $DB_NAME OWNER TO $DB_USER;"
-$STD sudo -u postgres psql -c "ALTER USER $DB_USER WITH SUPERUSER;"
-echo "" >>~/hoarder.creds
-echo -e "Hoarder Database User: $DB_USER" >>~/hoarder.creds
-echo -e "Hoarder Database Password: $DB_PASS" >>~/hoarder.creds
-echo -e "Hoarder Database Name: $DB_NAME" >>~/hoarder.creds
-echo -e "Hoarder Secret: $HOARDER_SECRET" >>~/hoarder.creds
-msg_ok "Set up PostgreSQL"
 
 msg_info "Installing Hoarder (Extreme Patience)"
 cd /opt
@@ -64,59 +58,162 @@ cd /opt/hoarder
 pnpm install --frozen-lockfile
 
 cd /opt/hoarder/packages/db
-pnpm dlx @vercel/ncc build migrate.ts -o /db_migrations
-cp -R drizzle /db_migrations
+pnpm dlx @vercel/ncc build migrate.ts -o ../../db_migrations
+cp -R drizzle /../..db_migrations
 
 cd /opt/hoarder/apps/web
 pnpm exec next build --experimental-build-mode compile
 
-#cd /opt/hoarder/apps/workers
-#pnpm deploy --node-linker=isolated --filter @hoarder/workers --prod /prod/workers
+cd /opt/hoarder/apps/workers
+pnpm deploy --node-linker=isolated --filter @hoarder/workers --prod workers
 
 cd /opt/hoarder/apps/cli
 pnpm build
 
 echo "${RELEASE}" >"/opt/hoarder_version.txt"
-cat <<EOF >/opt/hoarder/src/server/.env
-DATABASE_URL="postgresql://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME?schema=public"
+HOARDER_SECRET="$(openssl rand -base64 32 | cut c1-24)"
+MEILI_SECRET="$(openssl rand -base64 36)"
+echo "" >>~/hoarder.creds
+echo -e "NextAuth Secret: $HOARDER_SECRET" >>~/hoarder.creds
+echo -e "Meilisearch Master Key: $MEILI_SECRET" >>~/hoarder.creds
+
+cat <<EOF >/opt/hoarder/.env
 NEXTAUTH_SECRET="$HOARDER_SECRET"
-DATA_DIR="/data"
-MEILI_ADDR="http://127.0.0.1:7700"
-MEILI_MASTER_KEY="$(openssl rand -base64 36)"
 NEXTAUTH_URL="http://localhost:3000"
+DATA_DIR="/opt/hoarder/data"
+MEILI_ADDR="http://127.0.0.1:7700"
+MEILI_MASTER_KEY="$MEILI_SECRET"
+BROWSER_WEB_URL="http://127.0.0.1:9222"
+CRAWLER_VIDEO_DOWNLOAD=true
+#CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE=
+#OLLAMA_BASE_URL=
+#INFERENCE_TEXT_MODEL=
+#INFERENCE_IMAGE_MODEL=
 EOF
-cd /opt/hoarder/src/server
-$STD pnpm db:migrate:apply
+# cd /opt/hoarder/src/server
+# $STD pnpm db:migrate:apply
 msg_ok "Installed Hoarder"
 
-msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/hoarder.service
+msg_info "Creating users and Services"
+
+/usr/sbin/useradd -U -s /usr/sbin/nologin -r -m -d /var/lib/meilisearch meilisearch
+
+cat <<EOF >/lib/systemd/system/meilisearch.service
 [Unit]
-Description=Hoarder Server
-After=network.target
+Description=MeiliSearch is a RESTful search API
+Documentation=https://docs.meilisearch.com/
+Requires=network-online.target
+After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/node /opt/hoarder/src/server/dist/src/server/main.js
-WorkingDirectory=/opt/hoarder/src/server
-Restart=always
-RestartSec=10
-
-Environment=NODE_ENV=production
+User=meilisearch
+Group=meilisearch
+Restart=on-failure
+WorkingDirectory=/var/lib/meilisearch
+ExecStart=/usr/bin/meilisearch --no-analytics
+EnvironmentFile=/etc/meilisearch.conf
+NoNewPrivileges=true
+ProtectHome=true
+ReadWritePaths=/var/lib/meilisearch
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectKernelLogs=true
+ProtectClock=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateTmp=true
+CapabilityBoundingSet=
+RemoveIPC=true
 
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now hoarder.service
-msg_ok "Created Service"
+
+cat <<EOF >/etc/meilisearch.conf
+MEILI_MASTER_KEY="$MEILI_SECRET"
+EOF
+
+cat <<EOF >/etc/systemd/system/hoarder-browser.service
+[Unit]
+Description=Hoarder browser
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/bin/chromium-shell --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --hide-scrollbars
+TimeoutStopSec=5
+SyslogIdentifier=hoarder-browser
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/hoarder-workers.service
+[Unit]
+Description=Hoarder workers
+Wants=network-online.target hoarder-browser.service
+After=network-online.target hoarder-browser.service
+
+[Service]
+Restart=on-failure
+EnvironmentFile=/opt/hoarder/.env
+WorkingDirectory=/opt/hoarder/apps/workers
+ExecStart=/usr/bin/pnpm run start:prod
+TimeoutStopSec=5
+SyslogIdentifier=hoarder-workers
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/hoarder-web.service
+[Unit]
+Description=Hoarder web
+Wants=network-online.target hoarder-workers.service meilisearch.service
+After=network-online.target hoarder-workers.service meilisearch.service
+
+[Service]
+Restart=on-failure
+Environment=SERVER_VERSION=$RELEASE
+Environment=NODE_ENV=production
+EnvironmentFile=-/opt/hoarder/.env
+WorkingDirectory=/opt/hoarder/db_migrations
+ExecStartPre=/usr/bin/node index.js
+ExecStart=/usr/bin/node /opt/hoarder/apps/web/server.js
+TimeoutStopSec=5
+SyslogIdentifier=hoarder-web
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/hoarder.target
+[Unit]
+Description=Hoarder Services
+After=network-online.target
+Wants=hoarder-web.service hoarder-workers.service hoarder-browser.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+# systemctl enable -q --now meilisearch.service hoarder.target
+msg_ok "Created users and Services"
 
 motd_ssh
 customize
 
 msg_info "Cleaning up"
 rm -R /opt/v${RELEASE}.zip
-rm -rf /opt/hoarder/src/client
-rm -rf /opt/hoarder/website
-rm -rf /opt/hoarder/reporter
+#rm -rf /opt/hoarder/src/client
+#rm -rf /opt/hoarder/website
+#rm -rf /opt/hoarder/reporter
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"

--- a/misc/build.func
+++ b/misc/build.func
@@ -597,9 +597,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -629,7 +629,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -693,7 +693,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/install/$var_install.sh)" || exit
 
 }
 
@@ -705,7 +705,7 @@ description() {
   DESCRIPTION=$(cat <<EOF
 <div align='center'>
   <a href='https://Helper-Scripts.com' target='_blank' rel='noopener noreferrer'>
-    <img src='https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
+    <img src='https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
   </a>
 
   <h2 style='font-size: 24px; margin: 20px 0;'>${APP} LXC</h2>

--- a/misc/build.func
+++ b/misc/build.func
@@ -597,9 +597,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -629,7 +629,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -693,7 +693,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/install/$var_install.sh)" || exit
 
 }
 
@@ -705,7 +705,7 @@ description() {
   DESCRIPTION=$(cat <<EOF
 <div align='center'>
   <a href='https://Helper-Scripts.com' target='_blank' rel='noopener noreferrer'>
-    <img src='https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
+    <img src='https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
   </a>
 
   <h2 style='font-size: 24px; margin: 20px 0;'>${APP} LXC</h2>
@@ -718,15 +718,15 @@ description() {
   
   <span style='margin: 0 10px;'>
     <i class="fa fa-github fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/MickLesk/Proxmox_DEV' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>
+    <a href='https://github.com/vhsdream/prox-script-dev' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>
   </span>
   <span style='margin: 0 10px;'>
     <i class="fa fa-comments fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/MickLesk/Proxmox_DEV/discussions' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Discussions</a>
+    <a href='https://github.com/vhsdream/prox-script-dev/discussions' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Discussions</a>
   </span>
   <span style='margin: 0 10px;'>
     <i class="fa fa-exclamation-circle fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/MickLesk/Proxmox_DEV/issues' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Issues</a>
+    <a href='https://github.com/vhsdream/prox-script-dev/issues' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Issues</a>
   </span>
 </div>
 EOF

--- a/misc/build.func
+++ b/misc/build.func
@@ -597,9 +597,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -629,7 +629,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -693,7 +693,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/install/$var_install.sh)" || exit
 
 }
 
@@ -705,7 +705,7 @@ description() {
   DESCRIPTION=$(cat <<EOF
 <div align='center'>
   <a href='https://Helper-Scripts.com' target='_blank' rel='noopener noreferrer'>
-    <img src='https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
+    <img src='https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
   </a>
 
   <h2 style='font-size: 24px; margin: 20px 0;'>${APP} LXC</h2>
@@ -718,15 +718,15 @@ description() {
   
   <span style='margin: 0 10px;'>
     <i class="fa fa-github fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/vhsdream/prox-script-dev' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>
+    <a href='https://github.com/MickLesk/Proxmox_DEV' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>
   </span>
   <span style='margin: 0 10px;'>
     <i class="fa fa-comments fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/vhsdream/prox-script-dev/discussions' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Discussions</a>
+    <a href='https://github.com/MickLesk/Proxmox_DEV/discussions' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Discussions</a>
   </span>
   <span style='margin: 0 10px;'>
     <i class="fa fa-exclamation-circle fa-fw" style="color: #f5f5f5;"></i>
-    <a href='https://github.com/vhsdream/prox-script-dev/issues' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Issues</a>
+    <a href='https://github.com/MickLesk/Proxmox_DEV/issues' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>Issues</a>
   </span>
 </div>
 EOF

--- a/misc/build.func
+++ b/misc/build.func
@@ -580,9 +580,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -612,7 +612,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -676,7 +676,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/install/$var_install.sh)" || exit
 
 }
 
@@ -688,7 +688,7 @@ description() {
   DESCRIPTION=$(cat <<EOF
 <div align='center'>
   <a href='https://Helper-Scripts.com' target='_blank' rel='noopener noreferrer'>
-    <img src='https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
+    <img src='https://raw.githubusercontent.com/vhsdream/prox-script-dev/main/misc/images/logo-81x112.png' alt='Logo' style='width:81px;height:112px;'/>
   </a>
 
   <h2 style='font-size: 24px; margin: 20px 0;'>${APP} LXC</h2>

--- a/misc/install.func
+++ b/misc/install.func
@@ -217,6 +217,6 @@ EOF
     systemctl restart $(basename $(dirname $GETTY_OVERRIDE) | sed 's/\.d//')
     msg_ok "Customized Container"
   fi
-  echo "bash -c \"\$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/${app}.sh)\"" >/usr/bin/update
+  echo "bash -c \"\$(wget -qLO - https://github.com/vhsdream/prox-script-dev/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
 }

--- a/misc/install.func
+++ b/misc/install.func
@@ -217,6 +217,6 @@ EOF
     systemctl restart $(basename $(dirname $GETTY_OVERRIDE) | sed 's/\.d//')
     msg_ok "Customized Container"
   fi
-  echo "bash -c \"\$(wget -qLO - https://github.com/vhsdream/prox-script-dev/raw/main/ct/${app}.sh)\"" >/usr/bin/update
+  echo "bash -c \"\$(wget -qLO - https://github.com/MickLesk/Proxmox_DEV/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
 }


### PR DESCRIPTION
This PR offers a successful build of Hoarder, with essential optional dependencies included (Chromium, Monolith, Meilisearch). I've run it a few times on my node and it seems to build ok.

A few things:

- This has 4 systemd service files instead of 1 - for the browser, for the workers, for the web frontend, and a .target file so it is easier to start the app.
- There is also a meilisearch service file, that is not a part of the above.
- I messed with the paths in the /opt/hoarder folder. I bet that was not the greatest idea, and that could probably be optimized.
- I have not changed anything in the ct/hoarder.sh update_script function besides removing the old space and resources check and replacing with the new options; the actual updating part of it is not going to work now.
- After the successful build, the RAM gets reduced to 2GB - I found that 2GB build would fail during the web frontend build phase so 4 is a good number for that.